### PR TITLE
Overhaul list display of mods + add download counts and external links

### DIFF
--- a/src/components/partials/RichModDisplay.tsx
+++ b/src/components/partials/RichModDisplay.tsx
@@ -26,16 +26,18 @@ export const RichModDisplay = ({ data, buttonType, onClick }: Props) => {
               src={data.iconUrl}
               alt={`Icon of ${data.name}`}
               className="mr-4 h-16 w-16 rounded-2xl object-contain"
+              width={64}
+              height={64}
             />
           )}
         </div>
-        <div className="flex grow justify-between">
+        <div className="flex grow flex-col sm:flex-row sm:justify-between">
           <div className="flex flex-col">
             <div className="flex shrink-0 flex-wrap align-baseline">
               <h2 className="mr-2 text-xl font-bold">{data.name}</h2>
             </div>
             <p className="my-0.5 font-medium">{data.description}</p>
-            <div className="flex flex-wrap">
+            <div className="mb-2 flex flex-wrap">
               <a
                 className="flex items-center underline"
                 href={data.href}
@@ -47,21 +49,21 @@ export const RichModDisplay = ({ data, buttonType, onClick }: Props) => {
               </a>
             </div>
           </div>
-          <div className="min-w-fit text-right">
+          <div className="min-w-fit">
             {data.downloads && (
-              <div className="mb-2 flex items-center">
-                <ArrowDownTrayIcon className="ml-auto mr-1 h-4 w-4" />
-                <p>
+              <div className="mb-2 flex items-center sm:justify-end">
+                <ArrowDownTrayIcon className="mr-1 h-4 w-4" />
+                <p className="font-medium">
                   <strong>{numberFormat(data.downloads)}</strong> downloads
                 </p>
               </div>
             )}
-            <div className="flex flex-col items-end">
+            <div className="flex flex-col sm:items-end">
               {onClick && (
                 <>
                   {buttonType === 'delete' && (
                     <button
-                      className="primaryish-button bg-red-500"
+                      className="primaryish-button mb-2 bg-red-500"
                       onClick={onClick}
                     >
                       <TrashIcon className="block h-5 w-5" />
@@ -70,7 +72,7 @@ export const RichModDisplay = ({ data, buttonType, onClick }: Props) => {
                   )}
                   {buttonType === 'add' && (
                     <button
-                      className="primaryish-button bg-green-500"
+                      className="primaryish-button mb-2 bg-green-500"
                       onClick={onClick}
                     >
                       <PlusIcon className="block h-5 w-5" />

--- a/src/components/partials/RichModDisplay.tsx
+++ b/src/components/partials/RichModDisplay.tsx
@@ -2,37 +2,13 @@
 
 import type { RichMod } from '~/types/moddermore';
 
-import { providerFormat } from '~/lib/strings';
-import { PlusIcon, TrashIcon } from '@heroicons/react/20/solid';
-
-const SomeDetails = ({ data }: { data: RichMod }) => {
-  return (
-    <>
-      {data.iconUrl && (
-        <img
-          src={data.iconUrl}
-          alt={`Icon of ${data.name}`}
-          className="h-[64px] w-[64px] rounded-md opacity-80 transition-opacity group-hover:opacity-100"
-          width={64}
-          height={64}
-          loading="lazy"
-          decoding="async"
-        />
-      )}
-      <div className="flex w-full flex-col space-y-1">
-        <h2 className="text-xl font-semibold">{data.name}</h2>
-        {data.description && (
-          <h3 className="w-full text-sm text-zinc-800 dark:text-zinc-200">
-            {data.description}
-          </h3>
-        )}
-        <h3 className="text-xs font-medium text-zinc-600 dark:text-zinc-400">
-          {providerFormat(data.provider)}
-        </h3>
-      </div>
-    </>
-  );
-};
+import { providerFormat, numberFormat } from '~/lib/strings';
+import {
+  PlusIcon,
+  TrashIcon,
+  ArrowTopRightOnSquareIcon,
+  ArrowDownTrayIcon,
+} from '@heroicons/react/20/solid';
 
 interface Props {
   data: RichMod;
@@ -41,50 +17,72 @@ interface Props {
 }
 
 export const RichModDisplay = ({ data, buttonType, onClick }: Props) => {
-  if (onClick) {
-    if (buttonType === 'delete') {
-      return (
-        <div className="group flex space-x-4 rounded-sm bg-transparent p-4 text-left transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800">
-          <SomeDetails data={data} />
-          <button
-            className="flex-grow-0 self-center rounded-md p-2"
-            type="button"
-          >
-            <TrashIcon
-              className="block h-5 w-5 text-red-500"
-              onClick={onClick}
-            />
-          </button>
-        </div>
-      );
-    } else if (buttonType === 'add') {
-      return (
-        <div className="group flex space-x-4 rounded-sm bg-transparent p-4 text-left transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800">
-          <SomeDetails data={data} />
-          <button
-            className="flex-grow-0 self-center rounded-md p-2"
-            type="button"
-          >
-            <PlusIcon
-              className="block h-5 w-5 text-green-500"
-              onClick={onClick}
-            />
-          </button>
-        </div>
-      );
-    } else {
-      return null;
-    }
-  }
-
   return (
-    <a
-      className="group flex space-x-4 rounded-sm bg-transparent p-4 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800"
-      href={data.href}
-      target="_blank"
-      rel="noreferrer noopener"
-    >
-      <SomeDetails data={data} />
-    </a>
+    <div className="flex justify-between rounded-2xl border-none bg-zinc-100 p-4 pt-4 shadow-sm dark:bg-zinc-800">
+      <div className="flex w-full">
+        <div className="shrink-0">
+          {data.iconUrl && (
+            <img
+              src={data.iconUrl}
+              alt={`Icon of ${data.name}`}
+              className="mr-4 h-16 w-16 rounded-2xl object-contain"
+            />
+          )}
+        </div>
+        <div className="flex grow justify-between">
+          <div className="flex flex-col">
+            <div className="flex shrink-0 flex-wrap align-baseline">
+              <h2 className="mr-2 text-xl font-bold">{data.name}</h2>
+            </div>
+            <p className="my-0.5 font-medium">{data.description}</p>
+            <div className="flex flex-wrap">
+              <a
+                className="flex items-center underline"
+                href={data.href}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                {providerFormat(data.provider)}
+                <ArrowTopRightOnSquareIcon className="mr-auto ml-1 h-4 w-4" />
+              </a>
+            </div>
+          </div>
+          <div className="min-w-fit text-right">
+            {data.downloads && (
+              <div className="mb-2 flex items-center">
+                <ArrowDownTrayIcon className="ml-auto mr-1 h-4 w-4" />
+                <p>
+                  <strong>{numberFormat(data.downloads)}</strong> downloads
+                </p>
+              </div>
+            )}
+            <div className="flex flex-col items-end">
+              {onClick && (
+                <>
+                  {buttonType === 'delete' && (
+                    <button
+                      className="primaryish-button bg-red-500"
+                      onClick={onClick}
+                    >
+                      <TrashIcon className="block h-5 w-5" />
+                      <span>Delete</span>
+                    </button>
+                  )}
+                  {buttonType === 'add' && (
+                    <button
+                      className="primaryish-button bg-green-500"
+                      onClick={onClick}
+                    >
+                      <PlusIcon className="block h-5 w-5" />
+                      <span>Add</span>
+                    </button>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 };

--- a/src/lib/import/search.ts
+++ b/src/lib/import/search.ts
@@ -53,6 +53,7 @@ export const search = async ({
       name: rawMod.title,
       provider: 'modrinth',
       description: rawMod.description,
+      downloads: rawMod.downloads,
       iconUrl: rawMod.icon_url,
     }));
   } else if (platform === 'curseforge') {
@@ -87,6 +88,7 @@ export const search = async ({
       provider: 'curseforge',
       name: rawMod.name,
       description: rawMod.summary,
+      downloads: rawMod.downloadCount,
     }));
   }
 

--- a/src/lib/metadata/curseforge.ts
+++ b/src/lib/metadata/curseforge.ts
@@ -26,5 +26,6 @@ export const getInfo = async (id: string): Promise<RichMod | null> => {
     provider: 'curseforge',
     name: data.name,
     description: data.summary,
+    downloads: data.downloadCount,
   };
 };

--- a/src/lib/metadata/modrinth.ts
+++ b/src/lib/metadata/modrinth.ts
@@ -19,5 +19,6 @@ export const getInfo = async (id: string): Promise<RichMod | null> => {
     provider: 'modrinth',
     name: data.title,
     description: data.description,
+    downloads: data.downloads,
   };
 };

--- a/src/lib/strings.ts
+++ b/src/lib/strings.ts
@@ -1,5 +1,10 @@
 import type { ModLoader, ModProvider } from '~/types/moddermore';
 
+export const numberFormat = (value: number): string => {
+  const formatter = Intl.NumberFormat('en', { notation: 'compact' });
+  return formatter.format(value);
+};
+
 export const providerFormat = (prov: ModProvider) => {
   if (prov === 'curseforge') return 'CurseForge';
   else if (prov === 'modrinth') return 'Modrinth';

--- a/src/pages/edit/[id].tsx
+++ b/src/pages/edit/[id].tsx
@@ -199,21 +199,22 @@ const NewList: NextPage = () => {
           </div>
 
           {searchResults.length > 0 && (
-            <ul className="flex flex-col space-y-2">
+            <ul className="flex flex-wrap space-y-2">
               {searchResults.map((res) =>
                 inputMods.filter(
                   (m) => m.id === res.id && m.provider === res.provider
                 ).length > 0 ? (
                   <></>
                 ) : (
-                  <RichModDisplay
-                    data={res}
-                    key={res.id}
-                    buttonType="add"
-                    onClick={() => {
-                      setInputMods([...inputMods, res]);
-                    }}
-                  />
+                  <li className="w-full" key={res.id}>
+                    <RichModDisplay
+                      data={res}
+                      buttonType="add"
+                      onClick={() => {
+                        setInputMods([...inputMods, res]);
+                      }}
+                    />
+                  </li>
                 )
               )}
             </ul>

--- a/src/pages/list/[id].tsx
+++ b/src/pages/list/[id].tsx
@@ -251,10 +251,10 @@ const ListPage: NextPage<PageProps> = ({ data }) => {
         )}
       </div>
 
-      <ul className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <ul className="flex flex-wrap space-y-2">
         {resolvedMods ? (
           resolvedMods.map((mod) => (
-            <li className="block" key={mod.id}>
+            <li className="w-full" key={mod.id}>
               <RichModDisplay data={mod} />
             </li>
           ))

--- a/src/types/environment.d.ts
+++ b/src/types/environment.d.ts
@@ -1,6 +1,6 @@
 declare namespace NodeJS {
   interface ProcessEnv {
-    MONGODB_CONN_STRING: string;
+    MONGODB_URI: string;
     NEXT_PUBLIC_CURSEFORGE_API_KEY: string;
 
     /** Only available when deployed */

--- a/src/types/moddermore.ts
+++ b/src/types/moddermore.ts
@@ -17,6 +17,7 @@ export interface RichMod {
   provider: ModProvider;
   name: string;
   description?: string;
+  downloads?: number;
   iconUrl?: string;
   href: string;
   id: string;


### PR DESCRIPTION
Some small changes to the way mods are displayed in a list to make it easier to edit in manual mode, by adding external links to the original mod pages and adding a download count to all mods. Inspired by the way modrinth displays the mods on their site.

![Screenshot 2022-10-11 at 13 43 31](https://user-images.githubusercontent.com/116395651/197340651-fa19ba1e-1a08-47f1-a1a9-8251b629fad1.png)

Signed-off-by: lporu <116395651+lporu@users.noreply.github.com>