### PR TITLE
change: use `get(CF|Modrinth)Download` functions for packwiz

### DIFF
--- a/src/lib/export/curseforge.ts
+++ b/src/lib/export/curseforge.ts
@@ -65,6 +65,10 @@ export const getCFDownload = async ({
       url: latest.downloadUrl,
       type: 'direct',
       fileSize: latest.fileLength,
+      sha1: latest.hashes.filter((k) => k.algo === 1)[0].value,
+      projectId: latest.id,
+      fileId: latest.modId,
+      displayName: latest.displayName ?? latest.fileName,
     },
   ];
 };

--- a/src/lib/export/modrinth.ts
+++ b/src/lib/export/modrinth.ts
@@ -21,6 +21,8 @@ const getObjFromVersion = (
     type,
     hashes: primary.hashes,
     fileSize: primary.size,
+    displayName: v.name,
+    version: v.id,
   };
 };
 

--- a/src/lib/export/types.ts
+++ b/src/lib/export/types.ts
@@ -18,6 +18,8 @@ export interface ModrinthDownload {
     sha1: string;
     sha512: string;
   };
+  displayName: string;
+  version: string;
 }
 
 export interface CurseForgeDownload {
@@ -27,6 +29,10 @@ export interface CurseForgeDownload {
   type: 'direct' | 'dependency';
   provider: 'curseforge';
   fileSize: number;
+  sha1: string;
+  projectId: number;
+  fileId: number;
+  displayName: string;
 }
 
 export type Download = ModrinthDownload | CurseForgeDownload;


### PR DESCRIPTION
this modifies get(CF|Modrinth)Download functions to return additional metadata used by Packwiz and makes the Packwiz exporter use it.

this makes the exporter a whole lot better I think