### PR TITLE
fix: select latest Modrinth version by publish date

### DIFF
--- a/src/lib/export/upstream/modrinth.ts
+++ b/src/lib/export/upstream/modrinth.ts
@@ -20,6 +20,18 @@ const getObjFromVersion = (v: ModrinthVersion, type: "direct" | "dependency"): D
   };
 };
 
+const getLatestVersion = (versions: ModrinthVersion[]): ModrinthVersion | null => {
+  let latest: ModrinthVersion | null = null;
+
+  for (const version of versions) {
+    if (!latest || Date.parse(version.date_published) > Date.parse(latest.date_published)) {
+      latest = version;
+    }
+  }
+
+  return latest;
+};
+
 export const callModrinthAPI = async ({
   id,
   gameVersions,
@@ -46,15 +58,7 @@ export const callModrinthAPI = async ({
 
   const data = (await res.json()) as ModrinthVersion[];
 
-  let latest = data.find((v) => v.version_type === "release");
-  if (!latest) {
-    latest = data.find((v) => v.version_type === "beta");
-  }
-  if (!latest) {
-    latest = data.find((v) => v.version_type === "alpha");
-  }
-
-  return latest ?? null;
+  return getLatestVersion(data);
 };
 
 export const getModrinthDownload = async ({


### PR DESCRIPTION
﻿Fixes #653.

The Modrinth export path was picking the newest `release` first, then only falling back to beta/alpha if no release existed. That means a newer beta like Create Jetpack `4.4.2-fabric` could be ignored in favor of the older `4.3.0` release.

This changes the unlocked Modrinth version lookup to pick the compatible version with the newest `date_published`, regardless of whether Modrinth marks it as release, beta, or alpha. Locked versions still use the exact version id as before.

I checked the issue's Create Jetpack example against the Modrinth API: the old selection would pick `4.3.0` (`release`, 2025-01-07), while the new logic picks `4.4.2-fabric` (`beta`, 2026-03-11).

Checks:
- `pnpm exec tsx -e "import { callModrinthAPI } from './src/lib/export/upstream/modrinth.ts'; void (async () => { const version = await callModrinthAPI({ id: 'create-jetpack', name: 'Create Jetpack', gameVersions: ['1.20.1'], loader: 'fabric' }); console.log(version?.version_number, version?.version_type, version?.id); })();"`
- `pnpm exec prettier --check src/lib/export/upstream/modrinth.ts`
- `pnpm check`
- `pnpm lint`

I also ran `pnpm build`. It compiled and got through TypeScript, then stopped at page-data collection because the production MongoDB URI is required for that part of the build and I don't have that configured locally.
